### PR TITLE
Add OCR-based PDF splitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ This project aims to provide tools for parsing scanned notice documents from PDF
 
 ## Usage
 
-Run the main script with the path to a file or directory containing the notices:
+Run the main script with the path to the merged PDF containing multiple IRS letters. The script will OCR each page, analyze the text, and split the PDF into individual letters named using the date, taxpayer name, and notice type.
 
 ```bash
-python -m src.main /path/to/notices
+python -m src.main merged_notices.pdf output_dir
 ```
 
-The current implementation prints the provided path. Future versions will parse the documents with `pytesseract` and `pdfplumber`.
+Each resulting file will be named in the format `YYMMDD Taxpayer Name - IRSNOTICE.pdf`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pytesseract
 pdfplumber
 Pillow
+PyPDF2

--- a/src/letter_splitter.py
+++ b/src/letter_splitter.py
@@ -1,0 +1,86 @@
+import os
+import re
+from datetime import datetime
+from typing import List, Tuple
+
+import pdfplumber
+import pytesseract
+from PIL import Image
+from PyPDF2 import PdfReader, PdfWriter
+
+
+def _extract_text(page: pdfplumber.page.Page) -> str:
+    """OCR the given page and return extracted text."""
+    img = page.to_image(resolution=300)
+    pil_img: Image.Image = img.original
+    return pytesseract.image_to_string(pil_img)
+
+
+def _parse_info(text: str) -> Tuple[str, str, str]:
+    """Extract date, taxpayer name and notice name from page text."""
+    # Date formats like MM/DD/YY or Month DD, YYYY
+    date_match = re.search(r"(\d{1,2}/\d{1,2}/\d{2,4})", text)
+    date_str = "000000"
+    if date_match:
+        for fmt in ("%m/%d/%Y", "%m/%d/%y"):
+            try:
+                dt = datetime.strptime(date_match.group(1), fmt)
+                date_str = dt.strftime("%y%m%d")
+                break
+            except ValueError:
+                continue
+    name_match = re.search(r"Dear\s+([A-Z][A-Za-z ,.'-]+)", text)
+    name = name_match.group(1).strip().replace(",", "") if name_match else "Unknown"
+    notice_match = re.search(r"(CP\d+|Letter\s*\d+|Notice\s+[A-Z0-9]+)", text, re.I)
+    notice = notice_match.group(1).replace(" ", "") if notice_match else "IRSNotice"
+    return date_str, name, notice
+
+
+def split_letters(input_pdf: str, output_dir: str) -> List[str]:
+    """Split the input PDF into per-taxpayer letters.
+
+    Args:
+        input_pdf: Path to the merged PDF file.
+        output_dir: Directory where individual letters will be stored.
+
+    Returns:
+        List of file paths created.
+    """
+    os.makedirs(output_dir, exist_ok=True)
+    created_files: List[str] = []
+
+    with pdfplumber.open(input_pdf) as pdf:
+        reader = PdfReader(input_pdf)
+        writer = PdfWriter()
+        info = None
+        start_idx = 0
+
+        for idx, page in enumerate(pdf.pages):
+            text = _extract_text(page)
+            if info is None:
+                info = _parse_info(text)
+                writer.add_page(reader.pages[idx])
+                continue
+
+            # new letter heuristic: look for greeting and IRS header
+            if re.search(r"\bDear\b", text) and re.search(r"Internal Revenue Service", text, re.I):
+                # save previous letter
+                date_str, name, notice = info
+                filename = f"{date_str} {name} - {notice}.pdf"
+                out_path = os.path.join(output_dir, filename)
+                with open(out_path, "wb") as fh:
+                    writer.write(fh)
+                created_files.append(out_path)
+                writer = PdfWriter()
+                info = _parse_info(text)
+            writer.add_page(reader.pages[idx])
+
+        if writer.getNumPages() > 0 and info:
+            date_str, name, notice = info
+            filename = f"{date_str} {name} - {notice}.pdf"
+            out_path = os.path.join(output_dir, filename)
+            with open(out_path, "wb") as fh:
+                writer.write(fh)
+            created_files.append(out_path)
+
+    return created_files

--- a/src/main.py
+++ b/src/main.py
@@ -1,25 +1,30 @@
 """Entry point for the scanned notices parser."""
 
 import argparse
+import os
+
+from .letter_splitter import split_letters
 
 
-def parse_notices(input_path: str) -> None:
-    """Placeholder function for parsing scanned notice documents.
+def parse_notices(input_path: str, output_dir: str) -> None:
+    """Parse scanned notices and split them into individual letters."""
 
-    Args:
-        input_path: Path to the file or directory containing notices.
-    """
-    # TODO: Implement parsing logic using pytesseract and pdfplumber
-    print(f"Parsing notices from {input_path}")
-
+    created = split_letters(input_path, output_dir)
+    for fpath in created:
+        print(f"Created {fpath}")
 
 def main() -> None:
     """Command-line interface for the parser."""
     parser = argparse.ArgumentParser(description="Parse scanned notice documents")
-    parser.add_argument("path", help="Path to notice file or directory")
+    parser.add_argument("path", help="Path to merged notice PDF")
+    parser.add_argument(
+        "output",
+        help="Directory where individual letters will be written",
+        default="output",
+    )
     args = parser.parse_args()
 
-    parse_notices(args.path)
+    parse_notices(args.path, args.output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- create a `letter_splitter` module to OCR each page and split merged PDFs into per-taxpayer letters
- update the CLI in `src/main.py` to call the splitter
- document usage in `README.md`
- add `PyPDF2` to requirements

## Testing
- `python -m py_compile src/letter_splitter.py src/main.py`
- `pytest -q` *(fails: command not found)*