### PR TITLE
Add debug and analyze options

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,13 @@ This project aims to provide tools for parsing scanned notice documents from PDF
 
 Run the main script with the path to the merged PDF containing multiple IRS letters. The script will OCR each page, analyze the text, and split the PDF into individual letters named using the date, taxpayer name, and notice type.
 
+
 ```bash
 python -m src.main merged_notices.pdf output_dir
 ```
+
+Use `--debug` to see additional processing information on the console. The
+`--analyze` flag prints the OCR text of each page without writing any output
+files.
 
 Each resulting file will be named in the format `YYMMDD Taxpayer Name - IRSNOTICE.pdf`.

--- a/src/main.py
+++ b/src/main.py
@@ -1,9 +1,9 @@
 """Entry point for the scanned notices parser."""
 
 import argparse
-import os
+import logging
 
-from .letter_splitter import split_letters
+from .letter_splitter import analyze_pdf, split_letters
 
 
 def parse_notices(input_path: str, output_dir: str) -> None:
@@ -22,7 +22,23 @@ def main() -> None:
         help="Directory where individual letters will be written",
         default="output",
     )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable debug messages",
+    )
+    parser.add_argument(
+        "--analyze",
+        action="store_true",
+        help="Output OCR text for each page and exit",
+    )
     args = parser.parse_args()
+
+    logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO, format="%(message)s")
+
+    if args.analyze:
+        analyze_pdf(args.path)
+        return
 
     parse_notices(args.path, args.output)
 


### PR DESCRIPTION
## Summary
- allow running the parser with `--debug` to print detailed messages
- add `--analyze` option that outputs OCR text for each page
- log OCR operations in `letter_splitter`
- document new options in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
