### PR TITLE
Add debug and analyze options

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,13 @@ This project aims to provide tools for parsing scanned notice documents from PDF
 
 Run the main script with the path to the merged PDF containing multiple IRS letters. The script will OCR each page, analyze the text, and split the PDF into individual letters named using the date, taxpayer name, and notice type.
 
+
 ```bash
 python -m src.main merged_notices.pdf output_dir
 ```
+
+Use `--debug` to see additional processing information on the console. The
+`--analyze` flag prints the OCR text of each page without writing any output
+files.
 
 Each resulting file will be named in the format `YYMMDD Taxpayer Name - IRSNOTICE.pdf`.

--- a/src/letter_splitter.py
+++ b/src/letter_splitter.py
@@ -1,7 +1,10 @@
+import logging
 import os
 import re
 from datetime import datetime
 from typing import List, Tuple
+
+logger = logging.getLogger(__name__)
 
 import pdfplumber
 import pytesseract
@@ -13,7 +16,9 @@ def _extract_text(page: pdfplumber.page.Page) -> str:
     """Return text from the given page using embedded text if available, otherwise OCR."""
     text = page.extract_text() or ""
     if text.strip():
+        logger.debug("Using embedded text")
         return text
+    logger.debug("No embedded text found, performing OCR")
     img = page.to_image(resolution=300)
     pil_img: Image.Image = img.original
     return pytesseract.image_to_string(pil_img)
@@ -43,7 +48,16 @@ def _parse_info(text: str) -> Tuple[str, str, str]:
 
     notice_match = re.search(r"(CP\d+|Letter\s*\d+|Notice\s+[A-Z0-9]+)", text, re.I)
     notice = notice_match.group(1).replace(" ", "") if notice_match else "IRSNotice"
+    logger.debug("Parsed info - date: %s, name: %s, notice: %s", date_str, name, notice)
     return date_str, name, notice
+
+
+def _is_new_letter(text: str) -> bool:
+    """Return True if the text indicates the start of a new letter."""
+    return (
+        re.search(r"Internal Revenue Service", text, re.I)
+        and re.search(r"\bDear\b", text)
+    )
 
 
 def split_letters(input_pdf: str, output_dir: str) -> List[str]:
@@ -66,14 +80,15 @@ def split_letters(input_pdf: str, output_dir: str) -> List[str]:
         start_idx = 0
 
         for idx, page in enumerate(pdf.pages):
+            logger.debug("Processing page %d", idx + 1)
             text = _extract_text(page)
             if info is None:
                 info = _parse_info(text)
                 writer.add_page(reader.pages[idx])
                 continue
 
-            # new letter heuristic: look for greeting and IRS header
-            if re.search(r"\bDear\b", text) and re.search(r"Internal Revenue Service", text, re.I):
+            # detect the start of a new letter
+            if _is_new_letter(text):
                 # save previous letter
                 date_str, name, notice = info
                 filename = f"{date_str} {name} - {notice}.pdf"
@@ -81,6 +96,7 @@ def split_letters(input_pdf: str, output_dir: str) -> List[str]:
                 with open(out_path, "wb") as fh:
                     writer.write(fh)
                 created_files.append(out_path)
+                logger.debug("Wrote %s", out_path)
                 writer = PdfWriter()
                 info = _parse_info(text)
             writer.add_page(reader.pages[idx])
@@ -92,5 +108,17 @@ def split_letters(input_pdf: str, output_dir: str) -> List[str]:
             with open(out_path, "wb") as fh:
                 writer.write(fh)
             created_files.append(out_path)
+            logger.debug("Wrote %s", out_path)
 
     return created_files
+
+
+def analyze_pdf(input_pdf: str) -> None:
+    """Output OCR text for each page of the input PDF for debugging."""
+    with pdfplumber.open(input_pdf) as pdf:
+        for idx, page in enumerate(pdf.pages):
+            logger.info("Page %d", idx + 1)
+            text = _extract_text(page)
+            logger.info(text)
+            logger.info("-" * 40)
+

--- a/src/main.py
+++ b/src/main.py
@@ -1,9 +1,9 @@
 """Entry point for the scanned notices parser."""
 
 import argparse
-import os
+import logging
 
-from .letter_splitter import split_letters
+from .letter_splitter import analyze_pdf, split_letters
 
 
 def parse_notices(input_path: str, output_dir: str) -> None:
@@ -22,7 +22,23 @@ def main() -> None:
         help="Directory where individual letters will be written",
         default="output",
     )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable debug messages",
+    )
+    parser.add_argument(
+        "--analyze",
+        action="store_true",
+        help="Output OCR text for each page and exit",
+    )
     args = parser.parse_args()
+
+    logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO, format="%(message)s")
+
+    if args.analyze:
+        analyze_pdf(args.path)
+        return
 
     parse_notices(args.path, args.output)
 


### PR DESCRIPTION
## Summary
- allow running the parser with `--debug` to print detailed messages
- add `--analyze` option that outputs OCR text for each page
- log OCR operations in `letter_splitter`
- improve heuristic for detecting new letters

## Testing
- `python -m py_compile $(git ls-files '*.py')`
